### PR TITLE
Add property_type feature to valuation flow

### DIFF
--- a/app/models/openai_model.py
+++ b/app/models/openai_model.py
@@ -43,8 +43,9 @@ class OpenAIModel(ValuationModel):
             "You are a real estate valuation model. "
             "Respond ONLY with valid JSON containing keys "
             "base, low, high, confidence, trend_mom_pct, comps, insights, "
-            "sparkline, and factors. Use these features: "
-            f"{json.dumps(features)}"
+            "sparkline, and factors. "
+            f"The property type is {features.get('property_type')}. "
+            f"Use these features: {json.dumps(features)}"
         )
 
         try:

--- a/app/services/valuation_service.py
+++ b/app/services/valuation_service.py
@@ -132,6 +132,13 @@ class ValuationService:
             direction = "up" if trend_mom_pct > 0 else "down"
             insights.append(f"Local price index is {direction} {abs(trend_mom_pct):.1f}% MoM.")
 
+        # Basic heuristic: presence of unit indicators implies a condo/apt
+        property_type = (
+            "condo"
+            if any(token in addr_norm for token in ("#", "unit", "apt", "suite"))
+            else "house"
+        )
+
         # Shared feature dictionary passed to any model
         features = {
             "address_norm": addr_norm,
@@ -141,6 +148,7 @@ class ValuationService:
             "area_code": geo.area.code,
             "city": geo.city,
             "province": geo.province,
+            "property_type": property_type,
             "trend_mom_pct": trend_mom_pct,
             "comps_count": len(comps),
             "comps_avg_price": comps_avg or 0,


### PR DESCRIPTION
## Summary
- infer simple property_type (condo vs house) and include in model features
- mention property_type in OpenAI valuation prompt so it's considered

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b289655c588321a7b1e357d1f1c800